### PR TITLE
Adding a reference for linux network namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 Summary the training material from LXC to Docker and Kubernetes
 
 ## LXC
-  - namespace
+  - namespace:
+    - http://abregman.com/2016/09/29/linux-network-namespace/
   - cgroups
   - seccomp
   - chroot


### PR DESCRIPTION
Network namespaces allow you to have isolated network environments on a single host. In addition, processes on your system can be associated with a specific network namespace.